### PR TITLE
Mudar a velocidade do carrinho

### DIFF
--- a/vaivolta/vaiEVolta.js
+++ b/vaivolta/vaiEVolta.js
@@ -131,9 +131,9 @@ function VaiEVolta(svg, memories, counters){
             if (simulating){
                 // console.log("Simulando");
                 if (that.motorDir.value == 1 && that.carrinho.bbox().x<470){
-                    that.carrinho.dx(5);
+                    that.carrinho.dx(50);
                 } else if(that.motorEsq.value == 1 && that.carrinho.bbox().x>-30){
-                    that.carrinho.dx(-5);
+                    that.carrinho.dx(-50);
                 }
                 that.fdcEsq.value = that.carrinho.bbox().x<-5 && that.carrinho.bbox().x>-80;
                 that.fdcDir.value = that.carrinho.bbox().x>400 && that.carrinho.bbox().x<520;


### PR DESCRIPTION
A velocidade do carrinho está muito lenta. Isso está atrapalhando um pouco na hora de visualizar as mudanças que fizemos em ladder. Assim, se mudarmos a velocidade com que o carrinho anda, podemos avaliar mais rápido se nossas alterações estão dando certo.